### PR TITLE
Robot manager crashes when a robot goes out of bounds 

### DIFF
--- a/stdr_robot/src/sensors/laser.cpp
+++ b/stdr_robot/src/sensors/laser.cpp
@@ -97,6 +97,9 @@ namespace stdr_robot {
         yMap = _sensorTransform.getOrigin().y() / _map.info.resolution + 
           sin( angle ) * distance;
         
+        if (yMap * _map.info.width + xMap > _map.info.height*_map.info.width)
+          return;
+        
         if ( _map.data[ yMap * _map.info.width + xMap ] > 70 )
         {
           break;

--- a/stdr_robot/src/sensors/sonar.cpp
+++ b/stdr_robot/src/sensors/sonar.cpp
@@ -107,6 +107,9 @@ namespace stdr_robot {
           sin( sonarIter + tf::getYaw(_sensorTransform.getRotation()) ) 
             * distance;
         
+        if (yMap * _map.info.width + xMap > _map.info.height*_map.info.width)
+          return;
+        
         //!< Found obstacle
         if ( _map.data[ yMap * _map.info.width + xMap ] > 70 )
         {


### PR DESCRIPTION
This has to be addressed so ray casting should not search out of map bounds.
