### PR TITLE
Add support for non-circular robots

### DIFF
--- a/stdr_parser/src/stdr_parser_msg_creator.cpp
+++ b/stdr_parser/src/stdr_parser_msg_creator.cpp
@@ -86,6 +86,40 @@ namespace stdr_parser
   }
   
   /**
+  @brief Creates a message from a parsed file - template specialization for geometry_msgs::Point
+  @param n [Node*] The root node
+  @return The message
+   */
+  template <>
+  geometry_msgs::Point MessageCreator::createMessage(Node *n, unsigned int id)
+  {
+    geometry_msgs::Point msg;
+    std::vector<int> indexes;
+    // x
+    indexes = n->getTag("x");
+    if( indexes.size() == 0) {
+      msg.x = atof(Specs::specs["x"].default_value.c_str());
+    } else {
+      msg.x = atof(n->elements[indexes[0]]->elements[0]->value.c_str());
+    }
+    // y
+    indexes = n->getTag("y");
+    if( indexes.size() == 0) {
+      msg.y = atof(Specs::specs["y"].default_value.c_str());
+    } else {
+      msg.y = atof(n->elements[indexes[0]]->elements[0]->value.c_str());
+    }
+    // z
+    indexes = n->getTag("z");
+    if( indexes.size() == 0) {
+      msg.z = atof(Specs::specs["z"].default_value.c_str());
+    } else {
+      msg.z = atof(n->elements[indexes[0]]->elements[0]->value.c_str());
+    }
+    return msg;
+  }
+
+  /**
   @brief Creates a message from a parsed file - template specialization for stdr_msgs::Noise
   @param n [Node*] The root node
   @return The message
@@ -151,6 +185,16 @@ namespace stdr_parser
     {
       msg.radius = atof(specs->elements[indexes[0]]->elements[0]->
         value.c_str());
+    }
+    // search for points
+    indexes = specs->getTag("points");
+    if( indexes.size() != 0 ) {
+      specs = specs->elements[indexes[0]];
+      std::vector<int> points = specs->getTag("point");
+      for( unsigned int i = 0; i < points.size(); i++ ) {
+        msg.points.push_back(createMessage<geometry_msgs::Point>(
+              specs->elements[points[i]], i));
+      }
     }
     return msg;
   }

--- a/stdr_resources/resources/specifications/stdr_multiple_allowed.xml
+++ b/stdr_resources/resources/specifications/stdr_multiple_allowed.xml
@@ -1,4 +1,4 @@
 <specifications>
-  robot,laser,sonar
+  robot,laser,sonar,point
 </specifications>
 

--- a/stdr_robot/src/stdr_robot.cpp
+++ b/stdr_robot/src/stdr_robot.cpp
@@ -168,13 +168,15 @@ namespace stdr_robot
     int xMap = newPose.x / _map.info.resolution;
     int yMap = newPose.y / _map.info.resolution;
 
-    int x = xMap;
-    int y = yMap;
-
     for(unsigned int i = 0 ; i < _footprint.size() ; i++)
     {
-      int xx = x + (int)(_footprint[i].first / _map.info.resolution);
-      int yy = y + (int)(_footprint[i].second / _map.info.resolution);
+      double x = _footprint[i].first * cos(newPose.theta) -
+                 _footprint[i].second * sin(newPose.theta);
+      double y = _footprint[i].first * sin(newPose.theta) +
+                 _footprint[i].second * cos(newPose.theta);
+                 
+      int xx = xMap + (int)(x / _map.info.resolution);
+      int yy = yMap + (int)(y / _map.info.resolution);
 
       if(_map.data[ yy * _map.info.width + xx ] > 70)
       {
@@ -252,8 +254,13 @@ namespace stdr_robot
       //Check all footprint points
       for(unsigned int i = 0 ; i < _footprint.size() ; i++)
       {
-        int xx = x + _footprint[i].first / _map.info.resolution;
-        int yy = y + _footprint[i].second / _map.info.resolution;
+        double footprint_x = _footprint[i].first * cos(newPose.theta) -
+                   _footprint[i].second * sin(newPose.theta);
+        double footprint_y = _footprint[i].first * sin(newPose.theta) +
+                   _footprint[i].second * cos(newPose.theta);
+                   
+        int xx = x + footprint_x / _map.info.resolution;
+        int yy = y + footprint_y / _map.info.resolution;
 
         if(_map.data[ yy * _map.info.width + xx ] > 70)
         {

--- a/stdr_robot/src/stdr_robot.cpp
+++ b/stdr_robot/src/stdr_robot.cpp
@@ -98,12 +98,21 @@ namespace stdr_robot
           result->description.sonarSensors[sonarIter], getName(), n ) ) );
     }
 
-    float radius = result->description.footprint.radius;
-    for(unsigned int i = 0 ; i < 360 ; i++)
-    {
-      float x = cos(i * 3.14159265359 / 180.0) * radius;
-      float y = sin(i * 3.14159265359 / 180.0) * radius;
-      _footprint.push_back( std::pair<float,float>(x,y));
+    if( result->description.footprint.points.size() == 0 ) {
+      float radius = result->description.footprint.radius;
+      for(unsigned int i = 0 ; i < 360 ; i++)
+      {
+        float x = cos(i * 3.14159265359 / 180.0) * radius;
+        float y = sin(i * 3.14159265359 / 180.0) * radius;
+        _footprint.push_back( std::pair<float,float>(x,y));
+      }
+    } else {
+      for( unsigned int i = 0 ;
+          i < result->description.footprint.points.size() ; 
+          i++ ) {
+        geometry_msgs::Point p = result->description.footprint.points[i];
+        _footprint.push_back( std::pair<float,float>(p.x, p.y));
+      }
     }
 
     _motionControllerPtr.reset(


### PR DESCRIPTION
This adds support for parsing footprints, uses footprint points if available in the robot model, and rotates the footprint during collision checking, so that collision checks work properly.

This exposes an existing bug where map points that lie between footprint points are not collision-checked. This means that the robot can drive "onto" the end of a wall and become stuck on the wall in certain circumstances.
