### PR TITLE
More support for YAML-CPP 0.5+

### DIFF
--- a/stdr_parser/include/stdr_parser/stdr_parser_tools.h
+++ b/stdr_parser/include/stdr_parser/stdr_parser_tools.h
@@ -36,6 +36,19 @@
 #include <tinyxml.h>
 #include "yaml-cpp/yaml.h"
 
+#ifdef HAVE_NEW_YAMLCPP
+namespace YAML
+{
+  // The >> operator disappeared in yaml-cpp 0.5, so this function is
+  // added to provide support for code written under the yaml-cpp 0.3 API.
+  template<typename T>
+  void operator >> (const YAML::Node& node, T& i)
+  {
+    i = node.as<T>();
+  }
+}
+#endif
+
 #include "stdr_msgs/RobotMsg.h"
 #include "geometry_msgs/Pose2D.h"
 #include "geometry_msgs/Point.h"

--- a/stdr_parser/src/stdr_yaml_parser.cpp
+++ b/stdr_parser/src/stdr_yaml_parser.cpp
@@ -55,7 +55,9 @@ namespace stdr_parser
     #endif
     
     base_node->file_origin = file_name;
+#ifndef HAVE_NEW_YAMLCPP
     base_node->file_row = doc.GetMark().line;
+#endif
     
     parseLow(doc,base_node);
   }
@@ -75,7 +77,9 @@ namespace stdr_parser
       node >> s;
       new_node->value = s;
       new_node->file_origin = n->file_origin;
+#ifndef HAVE_NEW_YAMLCPP
       new_node->file_row = node.GetMark().line;
+#endif
       n->elements.push_back(new_node);
     }
     else if(node.Type() == YAML::NodeType::Sequence)
@@ -88,18 +92,32 @@ namespace stdr_parser
     else if(node.Type() == YAML::NodeType::Map)
     {
       std::string s;
+#ifdef HAVE_NEW_YAMLCPP
+      for(YAML::const_iterator it = node.begin() ; it != node.end() ; it++) 
+#else
       for(YAML::Iterator it = node.begin() ; it != node.end() ; it++) 
+#endif
       {
         Node* new_node = new Node();
+#ifdef HAVE_NEW_YAMLCPP
+        it->first >> s;
+#else
         it.first() >> s;
+#endif
         new_node->tag = s;
         new_node->file_origin = n->file_origin;
+#ifndef HAVE_NEW_YAMLCPP
         new_node->file_row = node.GetMark().line;
+#endif
         n->elements.push_back(new_node);
         if(s == "filename")
         {
           std::string file_name;
+#ifdef HAVE_NEW_YAMLCPP
+          it->second >> file_name;
+#else
           it.second() >> file_name;
+#endif
           std::string path = ros::package::getPath("stdr_resources") + 
               std::string("/resources/") + file_name;
           std::ifstream fin(path.c_str());
@@ -115,13 +133,19 @@ namespace stdr_parser
             parser.GetNextDocument(doc);
           #endif
           new_node->file_origin = file_name;
+#ifndef HAVE_NEW_YAMLCPP
           new_node->file_row = doc.GetMark().line;
+#endif
           
           parseLow(doc,new_node);
         }
         else
         {
+#ifdef HAVE_NEW_YAMLCPP
+          parseLow(it->second,new_node);
+#else
           parseLow(it.second(),new_node);
+#endif
         }
       }
     }


### PR DESCRIPTION
The new API doesn't have a method for mapping nodes to line numbers, so line numbers won't be correct. The rest of the features should work.

There is an issue open for the line number problem: https://code.google.com/p/yaml-cpp/issues/detail?id=200

The only place that I can see the line number being referenced from a YAML parsed document is at (https://github.com/stdr-simulator-ros-pkg/stdr_simulator/blob/hydro-devel/stdr_parser/src/stdr_parser.cpp#L106).

This is the only build error for compiling on Fedora 19 and 20, and probably affects Arch as well.
