### PR TITLE
Change internal map topic from "map" to "stdr_map"

### DIFF
--- a/stdr_gui/include/stdr_gui/stdr_gui_controller.h
+++ b/stdr_gui/include/stdr_gui/stdr_gui_controller.h
@@ -232,7 +232,7 @@ namespace stdr_gui
       void initializeCommunications(void);
       
       /**
-      @brief Receives the occupancy grid map from stdr_server. Connects to "map" ROS topic
+      @brief Receives the occupancy grid map from stdr_server. Connects to "stdr_map" ROS topic
       @param msg [const nav_msgs::OccupancyGrid&] The OGM message
       @return void
       **/

--- a/stdr_gui/src/stdr_gui/stdr_gui_controller.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_gui_controller.cpp
@@ -80,7 +80,7 @@ namespace stdr_gui
   void CGuiController::initializeCommunications(void)
   {
     map_subscriber_ = n_.subscribe(
-      "map", 
+      "stdr_map",
       1, 
       &CGuiController::receiveMap,
       this);
@@ -466,7 +466,7 @@ namespace stdr_gui
   }
 
   /**
-  @brief Receives the occupancy grid map from stdr_server. Connects to "map" \
+  @brief Receives the occupancy grid map from stdr_server. Connects to "stdr_map" \
   ROS topic
   @param msg [const nav_msgs::OccupancyGrid&] The OGM message
   @return void

--- a/stdr_robot/src/stdr_robot.cpp
+++ b/stdr_robot/src/stdr_robot.cpp
@@ -56,7 +56,7 @@ namespace stdr_robot
     _registerClientPtr->sendGoal(goal,
       boost::bind(&Robot::initializeRobot, this, _1, _2));
 
-    _mapSubscriber = n.subscribe("map", 1, &Robot::mapCallback, this);
+    _mapSubscriber = n.subscribe("stdr_map", 1, &Robot::mapCallback, this);
     _moveRobotService = n.advertiseService(
       getName() + "/replace", &Robot::moveRobotCallback, this);
 

--- a/stdr_server/src/map_server.cpp
+++ b/stdr_server/src/map_server.cpp
@@ -64,11 +64,11 @@ namespace stdr_server {
       &MapServer::publishTransform, this);
     
     //!< Latched publisher for metadata
-    metadata_pub= n.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
+    metadata_pub= n.advertise<nav_msgs::MapMetaData>("stdr_map_metadata", 1, true);
     metadata_pub.publish( meta_data_message_ );
     
     //!< Latched publisher for data
-    map_pub = n.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
+    map_pub = n.advertise<nav_msgs::OccupancyGrid>("stdr_map", 1, true);
     map_pub.publish( map_ );
   }
 


### PR DESCRIPTION
During the implementation of turtlebot_stdr simulator, there was no other way to make things work than changing the frame_id of the map to "world" (Because the frame_id map is actually representing the odometry frame and is not fixed) or running another map_server hosting the same map but with a different frame_id. I prefer the first solution as it consumes less ressources and I tested it on STDR, the frame_id doesn't seem to affect the good functionning of STDR.
