### PR TITLE
stdr_server: remove leading slash from frame_id

### DIFF
--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -538,7 +538,7 @@ namespace stdr_server {
     
     namedRobot.robot = description;
     
-    namedRobot.name = "/robot" + boost::lexical_cast<std::string>(_id++);
+    namedRobot.name = "robot" + boost::lexical_cast<std::string>(_id++);
     
     _robotMap.insert( std::make_pair(namedRobot.name, namedRobot) );
     


### PR DESCRIPTION
Related to #163.

This removes the leading slash of `header.frame_id` in laser scan messages.

Note that I have no idea of the implication of this change. Can you test that every thing works fine otherwise?
