### PR TITLE
Issue #178 implementation

### DIFF
--- a/stdr_parser/include/stdr_parser/stdr_parser_tools.h
+++ b/stdr_parser/include/stdr_parser/stdr_parser_tools.h
@@ -79,5 +79,13 @@ namespace stdr_parser
   @return std::string
   **/
   std::string extractFilename(std::string s);
+
+  /**
+  @brief Extracts the directory from an absolute path. It does the
+  same functionality as libgen's dirname but for std::string objects
+  @param s [std::string] The input string
+  @return std::string
+  **/
+  std::string extractDirname(std::string s);
 }
 #endif

--- a/stdr_parser/src/stdr_parser_tools.cpp
+++ b/stdr_parser/src/stdr_parser_tools.cpp
@@ -54,4 +54,16 @@ namespace stdr_parser
     int n = s.find_last_of('/');
     return s.substr(n + 1, s.size() - n - 1);
   }
+
+  /**
+  @brief Extracts the directory from an absolute path. It does the
+  same functionality as libgen's dirname but for std::string objects
+  @param s [std::string] The input string
+  @return std::string
+  **/
+  std::string extractDirname(std::string s)
+  {
+    int n = s.find_last_of('/');
+    return s.substr(0, n); // exclude trailing '/'
+  }
 }

--- a/stdr_parser/src/stdr_xml_parser.cpp
+++ b/stdr_parser/src/stdr_xml_parser.cpp
@@ -66,7 +66,7 @@ malformed xml file");
   @param n [Node*] The stdr xml tree node to update
   @return void
   **/
-  void XmlParser::parseLow(TiXmlNode* node,Node* n)
+  void XmlParser::parseLow(TiXmlNode* node, Node* n)
   {
     Node* new_node = new Node();
     TiXmlNode* pChild;
@@ -95,13 +95,22 @@ malformed xml file");
           try
           {
             parse(ros::package::getPath("stdr_resources") + 
-              std::string("/resources/") + std::string(node->Value()) , n);
+              std::string("/resources/") + std::string(node->Value()), n);
           }
           catch(ParserException ex)
           {
-            throw ex;
+            try
+            {
+              // If not found on stdr_resources/resources,
+              // search on the directory containing parent file
+              parse(extractDirname(new_node->file_origin) +
+                std::string("/") + std::string(node->Value()), n);
+            }
+            catch(ParserException ex)
+            {
+              throw ex;
+            }
           }
-          
         }
         else
         {

--- a/stdr_parser/src/stdr_yaml_parser.cpp
+++ b/stdr_parser/src/stdr_yaml_parser.cpp
@@ -124,8 +124,15 @@ namespace stdr_parser
               std::string("/resources/") + file_name;
             std::ifstream fin(path.c_str());
             if (!fin.good()) {
-              throw ParserException("Failed to load '"+ file_name +
-                "', no such file!");
+              // If not found on stdr_resources/resources,
+              // search on the directory containing parent file
+              path = extractDirname(new_node->file_origin) +
+                std::string("/") + file_name;
+              fin.open(path.c_str());
+              if (!fin.good()) {
+                throw ParserException("Failed to load '"+ file_name +
+                  "', no such file!");
+              }
             }
 #ifdef HAVE_NEW_YAMLCPP
             YAML::Node doc = YAML::Load(fin);


### PR DESCRIPTION
I keep the function I did but renamed as extractDirname instead of using dirname (makes code uglier with char\* manipulations) and boost::filesystem (to avoid adding unnecessary boost dependencies).
