### PR TITLE
Angles laser beams evenly

### DIFF
--- a/stdr_robot/src/sensors/laser.cpp
+++ b/stdr_robot/src/sensors/laser.cpp
@@ -53,14 +53,20 @@ namespace stdr_robot {
     float angle;
     int distance;
     int xMap, yMap;
+    int divisions = 1;
     sensor_msgs::LaserScan _laserScan;
 
+    if ( _description.numRays > 1 )
+    {
+        divisions = _description.numRays - 1;
+    }
+    
     _laserScan.angle_min = _description.minAngle;
     _laserScan.angle_max = _description.maxAngle;
     _laserScan.range_max = _description.maxRange;
     _laserScan.range_min = _description.minRange;
     _laserScan.angle_increment = 
-      ( _description.maxAngle - _description.minAngle ) / ( _description.numRays - 1 );
+      ( _description.maxAngle - _description.minAngle ) / divisions;
 
 
     if ( _map.info.height == 0 || _map.info.width == 0 ) 
@@ -75,7 +81,7 @@ namespace stdr_robot {
       angle = tf::getYaw(_sensorTransform.getRotation()) + 
         _description.minAngle + laserScanIter * 
           ( _description.maxAngle - _description.minAngle ) 
-            / ( _description.numRays - 1 );
+            / divisions;
       
       distance = 1;
 

--- a/stdr_robot/src/sensors/laser.cpp
+++ b/stdr_robot/src/sensors/laser.cpp
@@ -60,7 +60,7 @@ namespace stdr_robot {
     _laserScan.range_max = _description.maxRange;
     _laserScan.range_min = _description.minRange;
     _laserScan.angle_increment = 
-      ( _description.maxAngle - _description.minAngle ) / _description.numRays;
+      ( _description.maxAngle - _description.minAngle ) / ( _description.numRays - 1 );
 
 
     if ( _map.info.height == 0 || _map.info.width == 0 ) 
@@ -75,7 +75,7 @@ namespace stdr_robot {
       angle = tf::getYaw(_sensorTransform.getRotation()) + 
         _description.minAngle + laserScanIter * 
           ( _description.maxAngle - _description.minAngle ) 
-            / _description.numRays;
+            / ( _description.numRays - 1 );
       
       distance = 1;
 


### PR DESCRIPTION
Laser beams are currently unevenly spaced because the code is dividing the total angle range by the number of rays rather than the number of spaces between rays (that is, rays - 1). Take, for example, the range [-45, 45] using 3 rays. The total angular range, 90, divided by 3, is 30. Beams will be placed at 0, 30, and 60. We want them placed at 0, 45, and 90, the result of dividing by rays - 1.
