### PR TITLE
Visualization for custom sources using Marker msgs

### DIFF
--- a/stdr_server/CMakeLists.txt
+++ b/stdr_server/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories( include ${catkin_INCLUDE_DIRS})
 
 add_library(stdr_map_loader src/map_loader.cpp)
 target_link_libraries(stdr_map_loader
+    image_loader
     yaml-cpp
     ${catkin_LIBRARIES}
 )

--- a/stdr_server/CMakeLists.txt
+++ b/stdr_server/CMakeLists.txt
@@ -37,7 +37,6 @@ include_directories( include ${catkin_INCLUDE_DIRS})
 
 add_library(stdr_map_loader src/map_loader.cpp)
 target_link_libraries(stdr_map_loader
-    image_loader
     yaml-cpp
     ${catkin_LIBRARIES}
 )

--- a/stdr_server/include/stdr_server/stdr_server.h
+++ b/stdr_server/include/stdr_server/stdr_server.h
@@ -37,6 +37,10 @@
 #include <stdr_msgs/RobotIndexedMsg.h>
 #include <stdr_msgs/RobotIndexedVectorMsg.h>
 
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
+#include <exception>
+
 #include <stdr_msgs/RfidTagVector.h>
 #include <stdr_msgs/AddRfidTag.h>
 #include <stdr_msgs/DeleteRfidTag.h>
@@ -260,8 +264,41 @@ namespace stdr_server {
         std::string &f_id);
       
     private:
-    
-      //!< THe ROS node handle
+      /**
+      @brief Translate the stdr_C02Source message into a marker message
+      @param msg [stdr_msgs::CO2Source] The GUI message to be translated
+      @return [visualization_msgs::Marker] the marker message to be published to Rviz
+	  **/
+      visualization_msgs::Marker translateC02(const stdr_msgs::CO2Source& msg);
+      
+      /**
+      @brief Translate the stdr_ThermalSource message into a marker message
+      @param msg [stdr_msgs::ThermalSource] The GUI message to be translated
+      @return [visualization_msgs::Marker] the marker message to be published to Rviz
+	  **/
+      visualization_msgs::Marker translateThermal(const stdr_msgs::ThermalSource& msg);
+      
+      /**
+      @brief Translate the stdr_SoundSource message into a marker message
+      @param msg [stdr_msgs::SoundSource] The GUI message to be translated
+      @return [visualization_msgs::Marker] the marker message to be published to Rviz
+	  **/
+      visualization_msgs::Marker translateSound(const stdr_msgs::SoundSource& msg);
+      
+      /**
+      @brief Translate the stdr_RfidTag message into a marker message
+      @param msg [stdr_msgs::RfidTag] The GUI message to be translated
+      @return [visualization_msgs::Marker] the marker message to be published to Rviz
+	  **/
+      visualization_msgs::Marker translateRFID(const stdr_msgs::RfidTag& msg);
+      
+      /**
+      @brief Creates a marker message corresponding to every element of msg that is 
+      independent of the source's specific type 
+      **/
+      template <class SourceMsg> visualization_msgs::Marker createMarker(const SourceMsg& msg);
+      
+      //!< The ROS node handle
       ros::NodeHandle _nh;
       //!< A pointer to a MapServe object
       MapServerPtr _mapServer;
@@ -306,6 +343,10 @@ namespace stdr_server {
       //!< Boost condition variable for conflicting avoidance
       boost::condition_variable cond;
       
+      
+      //!< A general Rviz publisher for all source types
+      ros::Publisher _sourceVectorPublisherRviz;
+      
       //!< The addRfidTag srv server
       ros::ServiceServer _addRfidTagServiceServer;
       //!< The deleteRfidTag srv server
@@ -313,11 +354,12 @@ namespace stdr_server {
       //!< The rfid tag list publisher
       ros::Publisher _rfidTagVectorPublisher;
       
+      
       //!< The addCO2Source srv server
       ros::ServiceServer _addCO2SourceServiceServer;
       //!< The deleteCO2Source srv server
       ros::ServiceServer _deleteCO2SourceServiceServer;
-      //!< The CO2 source list publisher
+      //!< The CO2 source list publisher towards the GUI.
       ros::Publisher _CO2SourceVectorPublisher;
       
       //!< The addThermalSource srv server

--- a/stdr_server/include/stdr_server/stdr_server.h
+++ b/stdr_server/include/stdr_server/stdr_server.h
@@ -39,7 +39,6 @@
 
 #include <visualization_msgs/Marker.h>
 #include <visualization_msgs/MarkerArray.h>
-#include <exception>
 
 #include <stdr_msgs/RfidTagVector.h>
 #include <stdr_msgs/AddRfidTag.h>
@@ -263,34 +262,33 @@ namespace stdr_server {
       bool hasDublicateFrameIds(const stdr_msgs::RobotMsg& robot, 
         std::string &f_id);
       
-    private:
       /**
       @brief Translate the stdr_C02Source message into a marker message
       @param msg [stdr_msgs::CO2Source] The GUI message to be translated
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker translateC02(const stdr_msgs::CO2Source& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::CO2Source& msg);
       
       /**
       @brief Translate the stdr_ThermalSource message into a marker message
       @param msg [stdr_msgs::ThermalSource] The GUI message to be translated
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker translateThermal(const stdr_msgs::ThermalSource& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::ThermalSource& msg);
       
       /**
       @brief Translate the stdr_SoundSource message into a marker message
       @param msg [stdr_msgs::SoundSource] The GUI message to be translated
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker translateSound(const stdr_msgs::SoundSource& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::SoundSource& msg);
       
       /**
       @brief Translate the stdr_RfidTag message into a marker message
       @param msg [stdr_msgs::RfidTag] The GUI message to be translated
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker translateRFID(const stdr_msgs::RfidTag& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::RfidTag& msg);
       
       /**
       @brief Creates a marker message corresponding to every element of msg that is 

--- a/stdr_server/include/stdr_server/stdr_server.h
+++ b/stdr_server/include/stdr_server/stdr_server.h
@@ -293,10 +293,19 @@ namespace stdr_server {
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
       visualization_msgs::Marker toMarker(const stdr_msgs::RfidTag& msg,bool added);
+   
+      /**
+      @brief Republishes existing sources to RVIZ after a successful deletion.
+      @return [void]
+      **/
+      void republishSources();
       
       /**
       @brief Creates a marker message corresponding to every element of msg that is 
       independent of the source's specific type 
+      @param msg [SourceMsg] The source message
+      @param added [bool] True if the marker is added, false if it should be deleted
+      @return [visualization_msgs::Marker] the marker message to be published to Rviz
       **/
       template <class SourceMsg> visualization_msgs::Marker createMarker(const SourceMsg& msg,bool added);
       

--- a/stdr_server/include/stdr_server/stdr_server.h
+++ b/stdr_server/include/stdr_server/stdr_server.h
@@ -265,36 +265,40 @@ namespace stdr_server {
       /**
       @brief Translate the stdr_C02Source message into a marker message
       @param msg [stdr_msgs::CO2Source] The GUI message to be translated
+      @param added [bool] True if the marker is added, false if it should be deleted
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker toMarker(const stdr_msgs::CO2Source& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::CO2Source& msg,bool added);
       
       /**
       @brief Translate the stdr_ThermalSource message into a marker message
       @param msg [stdr_msgs::ThermalSource] The GUI message to be translated
+      @param added [bool] True if the marker is added, false if it should be deleted
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker toMarker(const stdr_msgs::ThermalSource& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::ThermalSource& msg,bool added);
       
       /**
       @brief Translate the stdr_SoundSource message into a marker message
       @param msg [stdr_msgs::SoundSource] The GUI message to be translated
+      @param added [bool] True if the marker is added, false if it should be deleted
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker toMarker(const stdr_msgs::SoundSource& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::SoundSource& msg,bool added);
       
       /**
       @brief Translate the stdr_RfidTag message into a marker message
       @param msg [stdr_msgs::RfidTag] The GUI message to be translated
+      @param added [bool] True if the marker is added, false if it should be deleted
       @return [visualization_msgs::Marker] the marker message to be published to Rviz
 	  **/
-      visualization_msgs::Marker toMarker(const stdr_msgs::RfidTag& msg);
+      visualization_msgs::Marker toMarker(const stdr_msgs::RfidTag& msg,bool added);
       
       /**
       @brief Creates a marker message corresponding to every element of msg that is 
       independent of the source's specific type 
       **/
-      template <class SourceMsg> visualization_msgs::Marker createMarker(const SourceMsg& msg);
+      template <class SourceMsg> visualization_msgs::Marker createMarker(const SourceMsg& msg,bool added);
       
       //!< The ROS node handle
       ros::NodeHandle _nh;

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -168,7 +168,7 @@ namespace stdr_server {
     for(RfidTagMapIt it = _rfidTagMap.begin() ; it != _rfidTagMap.end() ; it++)
     {
       rfidTagList.rfid_tags.push_back(it->second);
-      RFIDMarkerArray.markers.push_back(toMarker(it->second)); 
+      RFIDMarkerArray.markers.push_back(toMarker(it->second,true)); 
     }
     _rfidTagVectorPublisher.publish(rfidTagList);
 
@@ -207,7 +207,7 @@ namespace stdr_server {
       ; it != _CO2SourceMap.end() ; it++)
     {
       CO2SourceList.co2_sources.push_back(it->second);
-      C02MarkerArray.markers.push_back(toMarker(it->second));    
+      C02MarkerArray.markers.push_back(toMarker(it->second,true));    
     }
     _CO2SourceVectorPublisher.publish(CO2SourceList);
     _sourceVectorPublisherRviz.publish(C02MarkerArray); 
@@ -247,7 +247,7 @@ namespace stdr_server {
       ; it != _thermalSourceMap.end() ; it++)
     {
       thermalSourceList.thermal_sources.push_back(it->second);
-      thermalMarkerArray.markers.push_back(toMarker(it->second));
+      thermalMarkerArray.markers.push_back(toMarker(it->second,true));
     }
     _thermalSourceVectorPublisher.publish(thermalSourceList);
     _sourceVectorPublisherRviz.publish(thermalMarkerArray);
@@ -288,7 +288,7 @@ namespace stdr_server {
       ; it != _soundSourceMap.end() ; it++)
     {
       soundSourceList.sound_sources.push_back(it->second);
-      soundMarkerArray.markers.push_back(toMarker(it->second));
+      soundMarkerArray.markers.push_back(toMarker(it->second,true));
     }
     _soundSourceVectorPublisher.publish(soundSourceList); 
     _sourceVectorPublisherRviz.publish(soundMarkerArray);
@@ -311,21 +311,22 @@ namespace stdr_server {
     std::string name = req.name;
     if(_rfidTagMap.find(name) != _rfidTagMap.end())
     {
+      // Publish deletion to RVIZ
+      visualization_msgs::MarkerArray rfidMarkerArray;
+      rfidMarkerArray.markers.push_back(toMarker(_rfidTagMap[name],false));
+      _sourceVectorPublisherRviz.publish(rfidMarkerArray);
+
       _rfidTagMap.erase(name);
       
       //!< Publish the new RFID tag list
       stdr_msgs::RfidTagVector rfidTagList;
-      visualization_msgs::MarkerArray RFIDMarkerArray;
       
       for(RfidTagMapIt it = _rfidTagMap.begin() ; 
         it != _rfidTagMap.end() ; it++)
       {
         rfidTagList.rfid_tags.push_back(it->second);
-        RFIDMarkerArray.markers.push_back(toMarker(it->second));
       }
-      _rfidTagVectorPublisher.publish(rfidTagList);
-      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
-            
+      _rfidTagVectorPublisher.publish(rfidTagList);        
       
     }
     else  //!< Tag does not exist
@@ -346,21 +347,22 @@ namespace stdr_server {
     std::string name = req.name;
     if(_CO2SourceMap.find(name) != _CO2SourceMap.end())
     {
+      // Publish deletion to RVIZ
+      visualization_msgs::MarkerArray CO2MarkerArray;
+      CO2MarkerArray.markers.push_back(toMarker(_CO2SourceMap[name],false));
+      _sourceVectorPublisherRviz.publish(CO2MarkerArray);
+
       _CO2SourceMap.erase(name);
       
       //!< Publish the new sources list
       stdr_msgs::CO2SourceVector CO2SourceList;
-      visualization_msgs::MarkerArray C02MarkerArray;
       
       for(CO2SourceMapIt it = _CO2SourceMap.begin() ; 
         it != _CO2SourceMap.end() ; it++)
       {
         CO2SourceList.co2_sources.push_back(it->second);
-        C02MarkerArray.markers.push_back(toMarker(it->second));
       }
-      _CO2SourceVectorPublisher.publish(CO2SourceList);
-      _sourceVectorPublisherRviz.publish(C02MarkerArray);      
-      
+      _CO2SourceVectorPublisher.publish(CO2SourceList);       
       
     }
     else  //!< Source does not exist
@@ -381,22 +383,23 @@ namespace stdr_server {
     std::string name = req.name;
     if(_thermalSourceMap.find(name) != _thermalSourceMap.end())
     {
+      // Publish deletion to RVIZ
+      visualization_msgs::MarkerArray thermalMarkerArray;
+      thermalMarkerArray.markers.push_back(toMarker(_thermalSourceMap[name],false));
+      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+
       _thermalSourceMap.erase(name);
       
       //!< Publish the new sources list
       stdr_msgs::ThermalSourceVector thermalSourceList;
-      visualization_msgs::MarkerArray thermalMarkerArray;
       
       for(ThermalSourceMapIt it = _thermalSourceMap.begin() ; 
         it != _thermalSourceMap.end() ; it++)
       {
         thermalSourceList.thermal_sources.push_back(it->second);
-        thermalMarkerArray.markers.push_back(toMarker(it->second));
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
-      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
-      
-      
+       
     }
     else  //!< Source does not exist
     {
@@ -416,20 +419,25 @@ namespace stdr_server {
     std::string name = req.name;
     if(_soundSourceMap.find(name) != _soundSourceMap.end())
     {
+      // Publish deletion to RVIZ
+      visualization_msgs::MarkerArray soundMarkerArray;
+      soundMarkerArray.markers.push_back(toMarker(_soundSourceMap[name],false));
+      _sourceVectorPublisherRviz.publish(soundMarkerArray);
+
       _soundSourceMap.erase(name);
       
       //!< Publish the new sources list
       stdr_msgs::SoundSourceVector soundSourceList;
-      visualization_msgs::MarkerArray soundMarkerArray;
+
       
       for(SoundSourceMapIt it = _soundSourceMap.begin() ; 
         it != _soundSourceMap.end() ; it++)
       {
         soundSourceList.sound_sources.push_back(it->second);
-        soundMarkerArray.markers.push_back(toMarker(it->second));
+        
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
-      _sourceVectorPublisherRviz.publish(soundMarkerArray);
+
 
 
     }
@@ -738,9 +746,9 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_C02Source message into a marker message
   **/
-  visualization_msgs::Marker Server::toMarker(const stdr_msgs::CO2Source& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::CO2Source& msg, bool added)
   {
-	visualization_msgs::Marker marker = createMarker(msg);
+	visualization_msgs::Marker marker = createMarker(msg,added);
 	
 	// Set the namespace and id for this marker.  This serves to create a unique ID
     // Any marker sent with the same namespace and id will overwrite the old one
@@ -759,9 +767,9 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_ThermalSource message into a marker message
   **/
-  visualization_msgs::Marker Server::toMarker(const stdr_msgs::ThermalSource& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::ThermalSource& msg, bool added)
   {
-	visualization_msgs::Marker marker = createMarker(msg);
+	visualization_msgs::Marker marker = createMarker(msg,added);
 	
 	// Set the namespace and id for this marker.  This serves to create a unique ID
     // Any marker sent with the same namespace and id will overwrite the old one
@@ -780,9 +788,9 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_SoundSource message into a marker message
   **/
-  visualization_msgs::Marker Server::toMarker(const stdr_msgs::SoundSource& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::SoundSource& msg, bool added)
   {
-	visualization_msgs::Marker marker = createMarker(msg);
+	visualization_msgs::Marker marker = createMarker(msg,added);
 	
 	// Set the namespace and id for this marker.  This serves to create a unique ID
     // Any marker sent with the same namespace and id will overwrite the old one
@@ -801,9 +809,9 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_SoundSource message into a marker message
   **/
-  visualization_msgs::Marker Server::toMarker(const stdr_msgs::RfidTag& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::RfidTag& msg, bool added)
   {
-    visualization_msgs::Marker marker = createMarker(msg);
+    visualization_msgs::Marker marker = createMarker(msg,added);
 	
     // Set the namespace and id for this marker.  This serves to create a unique ID
     // Any marker sent with the same namespace and id will overwrite the old one
@@ -824,7 +832,7 @@ namespace stdr_server {
   @brief Creates a marker message corresponding to every element of msg that is 
   independent of the source's specific type 
   **/
-  template <class SourceMsg> visualization_msgs::Marker Server::createMarker(const SourceMsg& msg)
+  template <class SourceMsg> visualization_msgs::Marker Server::createMarker(const SourceMsg& msg, bool added)
   {
     visualization_msgs::Marker marker;
 
@@ -834,8 +842,13 @@ namespace stdr_server {
     uint32_t shape = visualization_msgs::Marker::SPHERE;
     marker.type = shape;
 
-    // Set the marker action.  Options are ADD, DELETE, and new in ROS Indigo: 3 (DELETEALL)
-    marker.action = visualization_msgs::Marker::ADD;
+    // Set the marker action.
+    if(added) {
+      marker.action = visualization_msgs::Marker::ADD;
+    }
+    else {
+      marker.action = visualization_msgs::Marker::DELETE;
+    }
 
     marker.pose.position.x = msg.pose.x;
     marker.pose.position.y = msg.pose.y;

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -168,7 +168,7 @@ namespace stdr_server {
     for(RfidTagMapIt it = _rfidTagMap.begin() ; it != _rfidTagMap.end() ; it++)
     {
       rfidTagList.rfid_tags.push_back(it->second);
-      RFIDMarkerArray.markers.push_back(translateRFID(it->second)); 
+      RFIDMarkerArray.markers.push_back(toMarker(it->second)); 
     }
     _rfidTagVectorPublisher.publish(rfidTagList);
     if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -210,7 +210,7 @@ namespace stdr_server {
       ; it != _CO2SourceMap.end() ; it++)
     {
       CO2SourceList.co2_sources.push_back(it->second);
-      C02MarkerArray.markers.push_back(translateC02(it->second));    
+      C02MarkerArray.markers.push_back(toMarker(it->second));    
     }
     _CO2SourceVectorPublisher.publish(CO2SourceList);
     if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -252,7 +252,7 @@ namespace stdr_server {
       ; it != _thermalSourceMap.end() ; it++)
     {
       thermalSourceList.thermal_sources.push_back(it->second);
-      thermalMarkerArray.markers.push_back(translateThermal(it->second));
+      thermalMarkerArray.markers.push_back(toMarker(it->second));
     }
     _thermalSourceVectorPublisher.publish(thermalSourceList);
     if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -295,7 +295,7 @@ namespace stdr_server {
       ; it != _soundSourceMap.end() ; it++)
     {
       soundSourceList.sound_sources.push_back(it->second);
-      soundMarkerArray.markers.push_back(translateSound(it->second));
+      soundMarkerArray.markers.push_back(toMarker(it->second));
     }
     _soundSourceVectorPublisher.publish(soundSourceList);
     if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -330,7 +330,7 @@ namespace stdr_server {
         it != _rfidTagMap.end() ; it++)
       {
         rfidTagList.rfid_tags.push_back(it->second);
-        RFIDMarkerArray.markers.push_back(translateRFID(it->second));
+        RFIDMarkerArray.markers.push_back(toMarker(it->second));
       }
       _rfidTagVectorPublisher.publish(rfidTagList);
       if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -367,7 +367,7 @@ namespace stdr_server {
         it != _CO2SourceMap.end() ; it++)
       {
         CO2SourceList.co2_sources.push_back(it->second);
-        C02MarkerArray.markers.push_back(translateC02(it->second));
+        C02MarkerArray.markers.push_back(toMarker(it->second));
       }
       _CO2SourceVectorPublisher.publish(CO2SourceList);
       if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -405,7 +405,7 @@ namespace stdr_server {
         it != _thermalSourceMap.end() ; it++)
       {
         thermalSourceList.thermal_sources.push_back(it->second);
-        thermalMarkerArray.markers.push_back(translateThermal(it->second));
+        thermalMarkerArray.markers.push_back(toMarker(it->second));
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
       if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -442,7 +442,7 @@ namespace stdr_server {
         it != _soundSourceMap.end() ; it++)
       {
         soundSourceList.sound_sources.push_back(it->second);
-        soundMarkerArray.markers.push_back(translateSound(it->second));
+        soundMarkerArray.markers.push_back(toMarker(it->second));
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
       if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
@@ -756,7 +756,7 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_C02Source message into a marker message
   **/
-  visualization_msgs::Marker Server::translateC02(const stdr_msgs::CO2Source& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::CO2Source& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
 	
@@ -777,7 +777,7 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_ThermalSource message into a marker message
   **/
-  visualization_msgs::Marker Server::translateThermal(const stdr_msgs::ThermalSource& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::ThermalSource& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
 	
@@ -798,7 +798,7 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_SoundSource message into a marker message
   **/
-  visualization_msgs::Marker Server::translateSound(const stdr_msgs::SoundSource& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::SoundSource& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
 	
@@ -819,14 +819,14 @@ namespace stdr_server {
   /**
   @brief Translate the stdr_SoundSource message into a marker message
   **/
-  visualization_msgs::Marker Server::translateRFID(const stdr_msgs::RfidTag& msg)
+  visualization_msgs::Marker Server::toMarker(const stdr_msgs::RfidTag& msg)
   {
-	visualization_msgs::Marker marker = createMarker(msg);
+    visualization_msgs::Marker marker = createMarker(msg);
 	
     // Set the namespace and id for this marker.  This serves to create a unique ID
     // Any marker sent with the same namespace and id will overwrite the old one
     marker.ns = "rfid";
-	marker.id = atoi(msg.tag_id.c_str());
+    marker.id = atoi(msg.tag_id.c_str());
 	
     // Set the color specific to the source type -- be sure to set alpha to something non-zero!
     marker.color.r = 0.0f;
@@ -844,7 +844,7 @@ namespace stdr_server {
   **/
   template <class SourceMsg> visualization_msgs::Marker Server::createMarker(const SourceMsg& msg)
   {
-	visualization_msgs::Marker marker;
+    visualization_msgs::Marker marker;
     // Set the frame ID and timestamp.  See the TF tutorials for information on these.
     marker.header.frame_id = "/world";
     marker.header.stamp = ros::Time::now();

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -86,7 +86,7 @@ namespace stdr_server {
     
     //!< Rviz publisher
     _sourceVectorPublisherRviz = _nh.advertise<visualization_msgs::MarkerArray>(
-      "/visualization_marker_array", 1, true);
+      "stdr_server/sources_visualization_markers", 1, true);
       
     //!< Rfid tags    
         
@@ -171,11 +171,8 @@ namespace stdr_server {
       RFIDMarkerArray.markers.push_back(toMarker(it->second)); 
     }
     _rfidTagVectorPublisher.publish(rfidTagList);
-    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-    {
-      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
-    }
 
+    _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
 
     //!< Return success
     res.success = true;
@@ -213,10 +210,8 @@ namespace stdr_server {
       C02MarkerArray.markers.push_back(toMarker(it->second));    
     }
     _CO2SourceVectorPublisher.publish(CO2SourceList);
-    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-    {
-      _sourceVectorPublisherRviz.publish(C02MarkerArray); 
-    }
+    _sourceVectorPublisherRviz.publish(C02MarkerArray); 
+    
 
     
     //!< Return success
@@ -255,10 +250,8 @@ namespace stdr_server {
       thermalMarkerArray.markers.push_back(toMarker(it->second));
     }
     _thermalSourceVectorPublisher.publish(thermalSourceList);
-    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-    {
-      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
-    }
+    _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+    
     
     
     
@@ -297,11 +290,9 @@ namespace stdr_server {
       soundSourceList.sound_sources.push_back(it->second);
       soundMarkerArray.markers.push_back(toMarker(it->second));
     }
-    _soundSourceVectorPublisher.publish(soundSourceList);
-    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-    {
-      _sourceVectorPublisherRviz.publish(soundMarkerArray);
-    }
+    _soundSourceVectorPublisher.publish(soundSourceList); 
+    _sourceVectorPublisherRviz.publish(soundMarkerArray);
+
     
     
     //!< Return success
@@ -333,10 +324,8 @@ namespace stdr_server {
         RFIDMarkerArray.markers.push_back(toMarker(it->second));
       }
       _rfidTagVectorPublisher.publish(rfidTagList);
-      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-      {
-        _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
-      }      
+      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
+            
       
     }
     else  //!< Tag does not exist
@@ -370,10 +359,7 @@ namespace stdr_server {
         C02MarkerArray.markers.push_back(toMarker(it->second));
       }
       _CO2SourceVectorPublisher.publish(CO2SourceList);
-      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-      {
-        _sourceVectorPublisherRviz.publish(C02MarkerArray); 
-      }      
+      _sourceVectorPublisherRviz.publish(C02MarkerArray);      
       
       
     }
@@ -408,10 +394,8 @@ namespace stdr_server {
         thermalMarkerArray.markers.push_back(toMarker(it->second));
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
-      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-      {
-        _sourceVectorPublisherRviz.publish(thermalMarkerArray);
-      }  
+      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+      
       
     }
     else  //!< Source does not exist
@@ -445,10 +429,8 @@ namespace stdr_server {
         soundMarkerArray.markers.push_back(toMarker(it->second));
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
-      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
-      {
-        _sourceVectorPublisherRviz.publish(soundMarkerArray);
-      } 
+      _sourceVectorPublisherRviz.publish(soundMarkerArray);
+
 
     }
     else  //!< Source does not exist
@@ -845,18 +827,16 @@ namespace stdr_server {
   template <class SourceMsg> visualization_msgs::Marker Server::createMarker(const SourceMsg& msg)
   {
     visualization_msgs::Marker marker;
-    // Set the frame ID and timestamp.  See the TF tutorials for information on these.
-    marker.header.frame_id = "/world";
-    marker.header.stamp = ros::Time::now();
 
-    // Set the marker type.  Initially this is CUBE, and cycles between that and SPHERE, ARROW, and CYLINDER
+    marker.header.frame_id = "/map_static";
+    marker.header.stamp = ros::Time();
+
     uint32_t shape = visualization_msgs::Marker::SPHERE;
     marker.type = shape;
 
     // Set the marker action.  Options are ADD, DELETE, and new in ROS Indigo: 3 (DELETEALL)
     marker.action = visualization_msgs::Marker::ADD;
 
-    // Set the pose of the marker.  This is a full 6DOF pose relative to the frame/time specified in the header
     marker.pose.position.x = msg.pose.x;
     marker.pose.position.y = msg.pose.y;
     marker.pose.position.z = 0;
@@ -865,7 +845,6 @@ namespace stdr_server {
     marker.pose.orientation.z = 0.0;
     marker.pose.orientation.w = 1.0;
 
-    // Set the scale of the marker -- 1x1x1 here means 1m on a side
     marker.scale.x = 0.5;
     marker.scale.y = 0.5;
     marker.scale.z = 0.5;

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -83,7 +83,11 @@ namespace stdr_server {
     _robotsPublisher = 
       _nh.advertise<stdr_msgs::RobotIndexedVectorMsg>
         ("stdr_server/active_robots", 10, true);
-        
+    
+    //!< Rviz publisher
+    _sourceVectorPublisherRviz = _nh.advertise<visualization_msgs::MarkerArray>(
+      "/visualization_marker_array", 1, true);
+      
     //!< Rfid tags    
         
     _addRfidTagServiceServer = _nh.advertiseService("stdr_server/add_rfid_tag",
@@ -159,11 +163,15 @@ namespace stdr_server {
     
     //!< Publish the new RFID tag list
     stdr_msgs::RfidTagVector rfidTagList;
+    visualization_msgs::MarkerArray RFIDMarkerArray;
+    
     for(RfidTagMapIt it = _rfidTagMap.begin() ; it != _rfidTagMap.end() ; it++)
     {
       rfidTagList.rfid_tags.push_back(it->second);
+      RFIDMarkerArray.markers.push_back(translateRFID(it->second)); 
     }
     _rfidTagVectorPublisher.publish(rfidTagList);
+    _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
 
     //!< Return success
     res.success = true;
@@ -182,7 +190,7 @@ namespace stdr_server {
     if(_CO2SourceMap.find(new_source.id) != _CO2SourceMap.end())
     { //!< A source exists with the same id
       res.success = false;
-      res.message = "Duplicate CO2 is";
+      res.message = "Duplicate CO2 id";
       return false;
     }
     
@@ -190,14 +198,18 @@ namespace stdr_server {
     _CO2SourceMap.insert(std::pair<std::string, stdr_msgs::CO2Source>(
       new_source.id, new_source));
     
-    //!< Publish the new source list
+    //!< Publish the new source list to both our custom GUI and Rviz.
     stdr_msgs::CO2SourceVector CO2SourceList;
+    visualization_msgs::MarkerArray C02MarkerArray;
+    
     for(CO2SourceMapIt it = _CO2SourceMap.begin() 
       ; it != _CO2SourceMap.end() ; it++)
     {
       CO2SourceList.co2_sources.push_back(it->second);
+      C02MarkerArray.markers.push_back(translateC02(it->second));    
     }
     _CO2SourceVectorPublisher.publish(CO2SourceList);
+    _sourceVectorPublisherRviz.publish(C02MarkerArray); 
     
     //!< Return success
     res.success = true;
@@ -226,12 +238,16 @@ namespace stdr_server {
     
     //!< Publish the new source list
     stdr_msgs::ThermalSourceVector thermalSourceList;
+    visualization_msgs::MarkerArray thermalMarkerArray;
+    
     for(ThermalSourceMapIt it = _thermalSourceMap.begin() 
       ; it != _thermalSourceMap.end() ; it++)
     {
       thermalSourceList.thermal_sources.push_back(it->second);
+      thermalMarkerArray.markers.push_back(translateThermal(it->second));
     }
     _thermalSourceVectorPublisher.publish(thermalSourceList);
+    _sourceVectorPublisherRviz.publish(thermalMarkerArray);
     
     //!< Return success
     res.success = true;
@@ -260,12 +276,16 @@ namespace stdr_server {
     
     //!< Publish the new source list
     stdr_msgs::SoundSourceVector soundSourceList;
+    visualization_msgs::MarkerArray soundMarkerArray;
+    
     for(SoundSourceMapIt it = _soundSourceMap.begin() 
       ; it != _soundSourceMap.end() ; it++)
     {
       soundSourceList.sound_sources.push_back(it->second);
+      soundMarkerArray.markers.push_back(translateSound(it->second));
     }
     _soundSourceVectorPublisher.publish(soundSourceList);
+    _sourceVectorPublisherRviz.publish(soundMarkerArray);
     
     //!< Return success
     res.success = true;
@@ -287,12 +307,16 @@ namespace stdr_server {
       
       //!< Publish the new RFID tag list
       stdr_msgs::RfidTagVector rfidTagList;
+      visualization_msgs::MarkerArray RFIDMarkerArray;
+      
       for(RfidTagMapIt it = _rfidTagMap.begin() ; 
         it != _rfidTagMap.end() ; it++)
       {
         rfidTagList.rfid_tags.push_back(it->second);
+        RFIDMarkerArray.markers.push_back(translateRFID(it->second));
       }
       _rfidTagVectorPublisher.publish(rfidTagList);
+      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
     }
     else  //!< Tag does not exist
     {
@@ -316,12 +340,16 @@ namespace stdr_server {
       
       //!< Publish the new sources list
       stdr_msgs::CO2SourceVector CO2SourceList;
+      visualization_msgs::MarkerArray C02MarkerArray;
+      
       for(CO2SourceMapIt it = _CO2SourceMap.begin() ; 
         it != _CO2SourceMap.end() ; it++)
       {
         CO2SourceList.co2_sources.push_back(it->second);
+        C02MarkerArray.markers.push_back(translateC02(it->second));
       }
       _CO2SourceVectorPublisher.publish(CO2SourceList);
+      _sourceVectorPublisherRviz.publish(C02MarkerArray); 
     }
     else  //!< Source does not exist
     {
@@ -345,12 +373,16 @@ namespace stdr_server {
       
       //!< Publish the new sources list
       stdr_msgs::ThermalSourceVector thermalSourceList;
+      visualization_msgs::MarkerArray thermalMarkerArray;
+      
       for(ThermalSourceMapIt it = _thermalSourceMap.begin() ; 
         it != _thermalSourceMap.end() ; it++)
       {
         thermalSourceList.thermal_sources.push_back(it->second);
+        thermalMarkerArray.markers.push_back(translateThermal(it->second));
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
+      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
     }
     else  //!< Source does not exist
     {
@@ -374,12 +406,16 @@ namespace stdr_server {
       
       //!< Publish the new sources list
       stdr_msgs::SoundSourceVector soundSourceList;
+      visualization_msgs::MarkerArray soundMarkerArray;
+      
       for(SoundSourceMapIt it = _soundSourceMap.begin() ; 
         it != _soundSourceMap.end() ; it++)
       {
         soundSourceList.sound_sources.push_back(it->second);
+        soundMarkerArray.markers.push_back(translateSound(it->second));
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
+      _sourceVectorPublisherRviz.publish(soundMarkerArray);
     }
     else  //!< Source does not exist
     {
@@ -682,5 +718,110 @@ namespace stdr_server {
     }
     return false;
   }
+  
+  /**
+  @brief Translate the stdr_C02Source message into a marker message
+  **/
+  visualization_msgs::Marker Server::translateC02(const stdr_msgs::CO2Source& msg)
+  {
+	visualization_msgs::Marker marker = createMarker(msg);
+	marker.id = atoi(msg.id.c_str());
+    // Set the color specific to the source type -- be sure to set alpha to something non-zero!
+    marker.color.r = 0.0f;
+    marker.color.g = 1.0f;
+    marker.color.b = 0.0f;
+    marker.color.a = 1.0;
+    
+    return marker;
+  }
+  
+  /**
+  @brief Translate the stdr_ThermalSource message into a marker message
+  **/
+  visualization_msgs::Marker Server::translateThermal(const stdr_msgs::ThermalSource& msg)
+  {
+	visualization_msgs::Marker marker = createMarker(msg);
+	marker.id = atoi(msg.id.c_str());
+    // Set the color specific to the source type -- be sure to set alpha to something non-zero!
+    marker.color.r = 1.0f;
+    marker.color.g = 0.0f;
+    marker.color.b = 0.0f;
+    marker.color.a = 1.0;
+    
+    return marker;
+  }
+  
+  /**
+  @brief Translate the stdr_SoundSource message into a marker message
+  **/
+  visualization_msgs::Marker Server::translateSound(const stdr_msgs::SoundSource& msg)
+  {
+	visualization_msgs::Marker marker = createMarker(msg);
+	marker.id = atoi(msg.id.c_str());
+    // Set the color specific to the source type -- be sure to set alpha to something non-zero!
+    marker.color.r = 0.0f;
+    marker.color.g = 0.0f;
+    marker.color.b = 1.0f;
+    marker.color.a = 1.0;
+    
+    return marker;
+  }
+  
+  /**
+  @brief Translate the stdr_SoundSource message into a marker message
+  **/
+  visualization_msgs::Marker Server::translateRFID(const stdr_msgs::RfidTag& msg)
+  {
+	visualization_msgs::Marker marker = createMarker(msg);
+	marker.id = atoi(msg.tag_id.c_str());
+    // Set the color specific to the source type -- be sure to set alpha to something non-zero!
+    marker.color.r = 0.0f;
+    marker.color.g = 0.0f;
+    marker.color.b = 0.0f;
+    marker.color.a = 1.0;
+    
+    return marker;
+  }
+  
+    
+  /**
+  @brief Creates a marker message corresponding to every element of msg that is 
+  independent of the source's specific type 
+  **/
+  template <class SourceMsg> visualization_msgs::Marker Server::createMarker(const SourceMsg& msg)
+  {
+	visualization_msgs::Marker marker;
+    // Set the frame ID and timestamp.  See the TF tutorials for information on these.
+    marker.header.frame_id = "/world";
+    marker.header.stamp = ros::Time::now();
 
+    // Set the namespace and id for this marker.  This serves to create a unique ID
+    // Any marker sent with the same namespace and id will overwrite the old one
+    marker.ns = "basic_shapes";
+
+    // Set the marker type.  Initially this is CUBE, and cycles between that and SPHERE, ARROW, and CYLINDER
+    uint32_t shape = visualization_msgs::Marker::SPHERE;
+    marker.type = shape;
+
+    // Set the marker action.  Options are ADD, DELETE, and new in ROS Indigo: 3 (DELETEALL)
+    marker.action = visualization_msgs::Marker::ADD;
+
+    // Set the pose of the marker.  This is a full 6DOF pose relative to the frame/time specified in the header
+    marker.pose.position.x = msg.pose.x;
+    marker.pose.position.y = msg.pose.y;
+    marker.pose.position.z = 0;
+    marker.pose.orientation.x = 0.0;
+    marker.pose.orientation.y = 0.0;
+    marker.pose.orientation.z = 0.0;
+    marker.pose.orientation.w = 1.0;
+
+    // Set the scale of the marker -- 1x1x1 here means 1m on a side
+    marker.scale.x = 0.5;
+    marker.scale.y = 0.5;
+    marker.scale.z = 0.5;
+    
+    marker.lifetime = ros::Duration();
+    return marker;
+  }
+  
 } // end of namespace stdr_robot

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -171,7 +171,11 @@ namespace stdr_server {
       RFIDMarkerArray.markers.push_back(translateRFID(it->second)); 
     }
     _rfidTagVectorPublisher.publish(rfidTagList);
-    _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
+    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+    {
+      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
+    }
+
 
     //!< Return success
     res.success = true;
@@ -209,7 +213,11 @@ namespace stdr_server {
       C02MarkerArray.markers.push_back(translateC02(it->second));    
     }
     _CO2SourceVectorPublisher.publish(CO2SourceList);
-    _sourceVectorPublisherRviz.publish(C02MarkerArray); 
+    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+    {
+      _sourceVectorPublisherRviz.publish(C02MarkerArray); 
+    }
+
     
     //!< Return success
     res.success = true;
@@ -247,7 +255,12 @@ namespace stdr_server {
       thermalMarkerArray.markers.push_back(translateThermal(it->second));
     }
     _thermalSourceVectorPublisher.publish(thermalSourceList);
-    _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+    {
+      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+    }
+    
+    
     
     //!< Return success
     res.success = true;
@@ -285,7 +298,11 @@ namespace stdr_server {
       soundMarkerArray.markers.push_back(translateSound(it->second));
     }
     _soundSourceVectorPublisher.publish(soundSourceList);
-    _sourceVectorPublisherRviz.publish(soundMarkerArray);
+    if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+    {
+      _sourceVectorPublisherRviz.publish(soundMarkerArray);
+    }
+    
     
     //!< Return success
     res.success = true;
@@ -316,7 +333,11 @@ namespace stdr_server {
         RFIDMarkerArray.markers.push_back(translateRFID(it->second));
       }
       _rfidTagVectorPublisher.publish(rfidTagList);
-      _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
+      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+      {
+        _sourceVectorPublisherRviz.publish(RFIDMarkerArray);
+      }      
+      
     }
     else  //!< Tag does not exist
     {
@@ -349,7 +370,12 @@ namespace stdr_server {
         C02MarkerArray.markers.push_back(translateC02(it->second));
       }
       _CO2SourceVectorPublisher.publish(CO2SourceList);
-      _sourceVectorPublisherRviz.publish(C02MarkerArray); 
+      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+      {
+        _sourceVectorPublisherRviz.publish(C02MarkerArray); 
+      }      
+      
+      
     }
     else  //!< Source does not exist
     {
@@ -382,7 +408,11 @@ namespace stdr_server {
         thermalMarkerArray.markers.push_back(translateThermal(it->second));
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
-      _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+      {
+        _sourceVectorPublisherRviz.publish(thermalMarkerArray);
+      }  
+      
     }
     else  //!< Source does not exist
     {
@@ -415,7 +445,11 @@ namespace stdr_server {
         soundMarkerArray.markers.push_back(translateSound(it->second));
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
-      _sourceVectorPublisherRviz.publish(soundMarkerArray);
+      if (_sourceVectorPublisherRviz.getNumSubscribers() >= 1)
+      {
+        _sourceVectorPublisherRviz.publish(soundMarkerArray);
+      } 
+
     }
     else  //!< Source does not exist
     {
@@ -725,7 +759,12 @@ namespace stdr_server {
   visualization_msgs::Marker Server::translateC02(const stdr_msgs::CO2Source& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
+	
+	// Set the namespace and id for this marker.  This serves to create a unique ID
+    // Any marker sent with the same namespace and id will overwrite the old one
+    marker.ns = "co2";
 	marker.id = atoi(msg.id.c_str());
+	
     // Set the color specific to the source type -- be sure to set alpha to something non-zero!
     marker.color.r = 0.0f;
     marker.color.g = 1.0f;
@@ -741,7 +780,12 @@ namespace stdr_server {
   visualization_msgs::Marker Server::translateThermal(const stdr_msgs::ThermalSource& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
+	
+	// Set the namespace and id for this marker.  This serves to create a unique ID
+    // Any marker sent with the same namespace and id will overwrite the old one
+    marker.ns = "thermal";
 	marker.id = atoi(msg.id.c_str());
+	
     // Set the color specific to the source type -- be sure to set alpha to something non-zero!
     marker.color.r = 1.0f;
     marker.color.g = 0.0f;
@@ -757,7 +801,12 @@ namespace stdr_server {
   visualization_msgs::Marker Server::translateSound(const stdr_msgs::SoundSource& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
+	
+	// Set the namespace and id for this marker.  This serves to create a unique ID
+    // Any marker sent with the same namespace and id will overwrite the old one
+    marker.ns = "sound";
 	marker.id = atoi(msg.id.c_str());
+	
     // Set the color specific to the source type -- be sure to set alpha to something non-zero!
     marker.color.r = 0.0f;
     marker.color.g = 0.0f;
@@ -773,7 +822,12 @@ namespace stdr_server {
   visualization_msgs::Marker Server::translateRFID(const stdr_msgs::RfidTag& msg)
   {
 	visualization_msgs::Marker marker = createMarker(msg);
+	
+    // Set the namespace and id for this marker.  This serves to create a unique ID
+    // Any marker sent with the same namespace and id will overwrite the old one
+    marker.ns = "rfid";
 	marker.id = atoi(msg.tag_id.c_str());
+	
     // Set the color specific to the source type -- be sure to set alpha to something non-zero!
     marker.color.r = 0.0f;
     marker.color.g = 0.0f;
@@ -794,10 +848,6 @@ namespace stdr_server {
     // Set the frame ID and timestamp.  See the TF tutorials for information on these.
     marker.header.frame_id = "/world";
     marker.header.stamp = ros::Time::now();
-
-    // Set the namespace and id for this marker.  This serves to create a unique ID
-    // Any marker sent with the same namespace and id will overwrite the old one
-    marker.ns = "basic_shapes";
 
     // Set the marker type.  Initially this is CUBE, and cycles between that and SPHERE, ARROW, and CYLINDER
     uint32_t shape = visualization_msgs::Marker::SPHERE;

--- a/stdr_server/src/stdr_server.cpp
+++ b/stdr_server/src/stdr_server.cpp
@@ -327,7 +327,8 @@ namespace stdr_server {
         rfidTagList.rfid_tags.push_back(it->second);
       }
       _rfidTagVectorPublisher.publish(rfidTagList);        
-      
+      //!< Republish existing sources to RVIZ.
+      republishSources();         
     }
     else  //!< Tag does not exist
     {
@@ -362,9 +363,11 @@ namespace stdr_server {
       {
         CO2SourceList.co2_sources.push_back(it->second);
       }
-      _CO2SourceVectorPublisher.publish(CO2SourceList);       
-      
+      _CO2SourceVectorPublisher.publish(CO2SourceList);
+      //!< Republish existing sources to RVIZ.
+      republishSources();        
     }
+
     else  //!< Source does not exist
     {
       return false;
@@ -399,7 +402,8 @@ namespace stdr_server {
         thermalSourceList.thermal_sources.push_back(it->second);
       }
       _thermalSourceVectorPublisher.publish(thermalSourceList);
-       
+      //!< Republish existing sources to RVIZ.
+      republishSources();          
     }
     else  //!< Source does not exist
     {
@@ -437,9 +441,8 @@ namespace stdr_server {
         
       }
       _soundSourceVectorPublisher.publish(soundSourceList);
-
-
-
+      //!< Republish existing sources to RVIZ.
+      republishSources();   
     }
     else  //!< Source does not exist
     {
@@ -827,7 +830,30 @@ namespace stdr_server {
     return marker;
   }
   
-    
+  void Server::republishSources()
+  {
+    visualization_msgs::MarkerArray ma;
+	for(SoundSourceMapIt it = _soundSourceMap.begin() 
+      ; it != _soundSourceMap.end() ; it++)
+    {
+        ma.markers.push_back(toMarker(it->second,true));
+    }
+    for(CO2SourceMapIt it = _CO2SourceMap.begin() 
+      ; it != _CO2SourceMap.end() ; it++)
+    {
+      ma.markers.push_back(toMarker(it->second,true));    
+    }
+    for(ThermalSourceMapIt it = _thermalSourceMap.begin() 
+      ; it != _thermalSourceMap.end() ; it++)
+    {
+      ma.markers.push_back(toMarker(it->second,true));
+    }
+    for(RfidTagMapIt it = _rfidTagMap.begin() ; it != _rfidTagMap.end() ; it++)
+    {
+      ma.markers.push_back(toMarker(it->second,true)); 
+    }
+    _sourceVectorPublisherRviz.publish(ma);  
+  }  
   /**
   @brief Creates a marker message corresponding to every element of msg that is 
   independent of the source's specific type 


### PR DESCRIPTION
# Abstract

Added a new visualization interface for all source types (plus RFID tags) to the stdr_server, #154. 
When new sources are added or deleted, an appropriate message is now published if rviz is subscribed to it (markerArrays should be enabled in Rviz).
As a result sources can be visualized not only in our custom **GUI** but also in **Rviz**.
## Implementation notes:

I created private functions able to translate the custom stdr messages into markerArray ones.
To avoid code duplication the main part of those functions is included into a template member function
responsible for creating a marker object and set every attribute that is not related to the specific source type.The specific translate functions only need to call this template and then only set the source type specific attributes themselves.

All callback functions in stdr_server responsible for adding or deleting sources used to publish towards the GUI controller. Now they also publish the (translated) message towards **rviz**, if the respective view is enabled.
## Testing:

Functionality can be tested by launching a GUI example as well as Rviz, for example:

`roslaunch stdr_launchers server_with_map_and_gui_plus_robot.launch`
`roslaunch stdr_launchers rviz.launch`

We then enable the markerArray visualization in Rviz.
Lastly we add one or more sources of any type through the stdr_gui and see it visualized in both the Gui and Rviz.
Of course adding sources in any other way (e.g through the map .yaml file) will also add visualize them in Rviz.
## Notes
1. Care has been taken to allow different source types to have the same ID.
2. Adding a source through the GUI some times gives an error message, this is also the case in the master branch
3. I am assuming that the user specifies an integer ID even though is it a string field. If that is not a case, a hash function should be added to create a unique ID for the markers.
