### PR TITLE
Redesign gui

### DIFF
--- a/stdr_gui/CMakeLists.txt
+++ b/stdr_gui/CMakeLists.txt
@@ -111,6 +111,7 @@ add_executable(stdr_gui_node
   src/stdr_gui/stdr_visualization/stdr_laser_visualization.cpp
   src/stdr_gui/stdr_visualization/stdr_sonar_visualization.cpp
   src/stdr_gui/stdr_visualization/stdr_robot_visualization.cpp
+  src/stdr_gui/stdr_map_metainformation/stdr_gui_source.cpp
   src/stdr_gui/stdr_map_metainformation/stdr_gui_co2_source.cpp
   src/stdr_gui/stdr_map_metainformation/stdr_gui_thermal_source.cpp
   src/stdr_gui/stdr_map_metainformation/stdr_gui_rfid_tag.cpp

--- a/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_co2_source.h
+++ b/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_co2_source.h
@@ -21,7 +21,7 @@
 #ifndef STDR_GUI_CO2_SOURCE_CONTAINER
 #define STDR_GUI_CO2_SOURCE_CONTAINER
 
-#include "stdr_gui/stdr_tools.h"
+#include "stdr_gui/stdr_map_metainformation/stdr_gui_source.h"
 
 /**
 @namespace stdr_gui
@@ -33,18 +33,12 @@ namespace stdr_gui
   @class CGuiCo2Source
   @brief Implements the functionalities of a CO2 source
   **/ 
-  class CGuiCo2Source
+  class CGuiCo2Source : public CGuiSource
   {
     //------------------------------------------------------------------------//
     private:
-      //!< The position of the rfid tag in the map
-      QPoint position_; 
-      //!< The "name" of the rfid tag 
-      std::string name_;  
-      //!< The message of the rfid tag
       float ppm_;
-      //!< The OGM resolution
-      float resolution_;
+      
     //------------------------------------------------------------------------//
     public:
       /**
@@ -63,24 +57,11 @@ namespace stdr_gui
       ~CGuiCo2Source(void);
       
       /**
-      @brief Returns the "name" of the rfid tag
-      @return std::string 
-      **/
-      std::string getName(void);
-      
-      /**
-      @brief Checks proximity to a point
-      @param p [QPoint] The proximity point to check
-      @return bool : True if tag is close to p
-      **/
-      bool checkProximity(QPoint p);
-      
-      /**
       @brief Draws the tag in the map
       @param img [QImage*] The image to draw to
       @return void
       **/
-      void draw(QImage *img);
+      virtual void draw(QImage *img);
       
       /**
       @brief Sets the tag message

--- a/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_rfid_tag.h
+++ b/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_rfid_tag.h
@@ -23,7 +23,7 @@
 #ifndef STDR_GUI_RFID_TAG_CONTAINER
 #define STDR_GUI_RFID_TAG_CONTAINER
 
-#include "stdr_gui/stdr_tools.h"
+#include "stdr_gui/stdr_map_metainformation/stdr_gui_source.h"
 
 /**
 @namespace stdr_gui
@@ -35,18 +35,13 @@ namespace stdr_gui
   @class CGuiRfidTag
   @brief Implements the functionalities of an RFID tag
   **/ 
-  class CGuiRfidTag
+  class CGuiRfidTag : public CGuiSource
   {
     //------------------------------------------------------------------------//
     private:
-      //!< The position of the rfid tag in the map
-      QPoint position_; 
-      //!< The "name" of the rfid tag 
-      std::string name_;  
       //!< The message of the rfid tag
       QString message_;
-      //!< The OGM resolution
-      float resolution_;
+
     //------------------------------------------------------------------------//
     public:
       /**
@@ -65,24 +60,11 @@ namespace stdr_gui
       ~CGuiRfidTag(void);
       
       /**
-      @brief Returns the "name" of the rfid tag
-      @return std::string 
-      **/
-      std::string getName(void);
-      
-      /**
-      @brief Checks proximity to a point
-      @param p [QPoint] The proximity point to check
-      @return bool : True if tag is close to p
-      **/
-      bool checkProximity(QPoint p);
-      
-      /**
       @brief Draws the tag in the map
       @param img [QImage*] The image to draw to
       @return void
       **/
-      void draw(QImage *img);
+      virtual void draw(QImage *img);
       
       /**
       @brief Sets the tag message

--- a/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_sound_source.h
+++ b/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_sound_source.h
@@ -21,7 +21,7 @@
 #ifndef STDR_GUI_SOUND_SOURCE_CONTAINER
 #define STDR_GUI_SOUND_SOURCE_CONTAINER
 
-#include "stdr_gui/stdr_tools.h"
+#include "stdr_gui/stdr_map_metainformation/stdr_gui_source.h"
 
 /**
 @namespace stdr_gui
@@ -33,18 +33,12 @@ namespace stdr_gui
   @class CGuiSoundSource
   @brief Implements the functionalities of a sound source
   **/ 
-  class CGuiSoundSource
+  class CGuiSoundSource : public CGuiSource
   {
     //------------------------------------------------------------------------//
     private:
-      //!< The position of the rfid tag in the map
-      QPoint position_; 
-      //!< The "name" of the rfid tag 
-      std::string name_;  
-      //!< The message of the rfid tag
       float db_;
-      //!< The OGM resolution
-      float resolution_;
+
     //------------------------------------------------------------------------//
     public:
       /**
@@ -63,24 +57,11 @@ namespace stdr_gui
       ~CGuiSoundSource(void);
       
       /**
-      @brief Returns the "name" of the rfid tag
-      @return std::string 
-      **/
-      std::string getName(void);
-      
-      /**
-      @brief Checks proximity to a point
-      @param p [QPoint] The proximity point to check
-      @return bool : True if tag is close to p
-      **/
-      bool checkProximity(QPoint p);
-      
-      /**
       @brief Draws the tag in the map
       @param img [QImage*] The image to draw to
       @return void
       **/
-      void draw(QImage *img);
+      virtual void draw(QImage *img);
       
       /**
       @brief Sets the tag message

--- a/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_source.h
+++ b/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_source.h
@@ -63,7 +63,7 @@ namespace stdr_gui
       @brief Default destructor
       @return void
       **/
-      ~CGuiSource(void);
+      virtual ~CGuiSource(void);
       
       /**
       @brief Returns the "name" of the source

--- a/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_source.h
+++ b/stdr_gui/include/stdr_gui/stdr_map_metainformation/stdr_gui_source.h
@@ -20,10 +20,12 @@
 ******************************************************************************/
 
 
-#ifndef STDR_GUI_THERMAL_SOURCE_CONTAINER
-#define STDR_GUI_THERMAL_SOURCE_CONTAINER
+#ifndef STDR_GUI_SOURCE_CONTAINER
+#define STDR_GUI_SOURCE_CONTAINER
 
-#include "stdr_gui/stdr_map_metainformation/stdr_gui_source.h"
+#include "stdr_gui/stdr_tools.h"
+#include <visualization_msgs/Marker.h>
+#include <visualization_msgs/MarkerArray.h>
 
 /**
 @namespace stdr_gui
@@ -32,52 +34,58 @@
 namespace stdr_gui
 {
   /**
-  @class CGuiThermalSource
-  @brief Implements the functionalities of a thermal source
+  @class CGuiSource
+  @brief Implements the functionalities of a source, to be derived by specific source types.
   **/ 
-  class CGuiThermalSource : public CGuiSource
+  class CGuiSource
   {
     //------------------------------------------------------------------------//
-    private:
-      //!< The degrees of the thermal source
-      float degrees_;
-
+    protected:
+      //!< The position of the source in the map
+      QPoint position_; 
+      //!< The "name" of the source tag 
+      std::string name_;  
+      //!< The OGM resolution
+      float resolution_;
+  	
     //------------------------------------------------------------------------//
     public:
       /**
       @brief Default contructor
-      @param p [QPoint] The pose of the rfid tag
-      @param name [std::string] The "name" of the rfid tag
+      @param p [QPoint] The pose of the source
+      @param name [std::string] The "name" of the source
       @param resolution [float] The map's resolution
       @return void
       **/
-      CGuiThermalSource(QPoint p,std::string name, float resolution);
+      CGuiSource(QPoint p,std::string name, float resolution);
       
       /**
       @brief Default destructor
       @return void
       **/
-      ~CGuiThermalSource(void);
+      ~CGuiSource(void);
       
       /**
-      @brief Draws the tag in the map
+      @brief Returns the "name" of the source
+      @return std::string 
+      **/
+      std::string getName(void);
+      
+      /**
+      @brief Checks proximity to a point
+      @param p [QPoint] The proximity point to check
+      @return bool : True if source is close to p
+      **/
+      
+      virtual bool checkProximity(QPoint p);
+      
+      /**
+      @brief Draws the source in the map
       @param img [QImage*] The image to draw to
       @return void
       **/
-      virtual void draw(QImage *img);
-      
-      /**
-      @brief Sets the tag message
-      @param msg [QString] The message to be set
-      @return void
-      **/
-      void setDegrees(float degrees);
-      
-      /**
-      @brief Returns the tag message
-      @return QString
-      **/
-      float getDegrees(void);
+      virtual void draw(QImage *img) = 0;
+
   };  
 }
 

--- a/stdr_gui/src/stdr_gui/stdr_gui_controller.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_gui_controller.cpp
@@ -79,6 +79,7 @@ namespace stdr_gui
   **/
   void CGuiController::initializeCommunications(void)
   {
+
     map_subscriber_ = n_.subscribe(
       "map", 
       1, 

--- a/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_co2_source.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_co2_source.cpp
@@ -30,12 +30,10 @@ namespace stdr_gui{
   @return void
   **/
   CGuiCo2Source::CGuiCo2Source(QPoint p,std::string name, float resolution):
-    position_(p),
-    name_(name),
-    resolution_(resolution),
+    CGuiSource(p,name,resolution),
     ppm_(0.0)
   {
-  
+	
   }
   
   /**
@@ -45,28 +43,6 @@ namespace stdr_gui{
   CGuiCo2Source::~CGuiCo2Source(void)
   {
 
-  }
-  
-  /**
-  @brief Returns the "name" of the rfid tag
-  @return std::string 
-  **/
-  std::string CGuiCo2Source::getName(void)
-  {
-    return name_;
-  }
-  
-  /**
-  @brief Checks proximity to a point
-  @param p [QPoint] The proximity point to check
-  @return bool : True if tag is close to p
-  **/
-  bool CGuiCo2Source::checkProximity(QPoint p)
-  {
-    float dx = p.x() * resolution_ - position_.x() * resolution_;
-    float dy = p.y() * resolution_ - position_.y() * resolution_;
-    float dist = sqrt( pow(dx,2) + pow(dy,2) );
-    return dist <= 0.3;
   }
   
   /**
@@ -87,7 +63,7 @@ namespace stdr_gui{
         2 * i * step, 
         2 * i * step);
     }
-    
+
     //!< Draws the label
     
     int text_size = name_.size();
@@ -117,6 +93,7 @@ namespace stdr_gui{
       position_.x() + 12,
       img->height() - position_.y() - 15,
       QString(name_.c_str()));
+    
   }
   
   /**

--- a/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_rfid_tag.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_rfid_tag.cpp
@@ -29,11 +29,10 @@ namespace stdr_gui{
   @param name [std::string] The "name" of the rfid tag
   @return void
   **/
+
   CGuiRfidTag::CGuiRfidTag(QPoint p,std::string name, float resolution):
-    position_(p),
-    name_(name),
-    resolution_(resolution),
-    message_("")
+	CGuiSource(p,name,resolution),
+        message_("")
   {
   
   }
@@ -46,29 +45,7 @@ namespace stdr_gui{
   {
 
   }
-  
-  /**
-  @brief Returns the "name" of the rfid tag
-  @return std::string 
-  **/
-  std::string CGuiRfidTag::getName(void)
-  {
-    return name_;
-  }
-  
-  /**
-  @brief Checks proximity to a point
-  @param p [QPoint] The proximity point to check
-  @return bool : True if tag is close to p
-  **/
-  bool CGuiRfidTag::checkProximity(QPoint p)
-  {
-    float dx = p.x() * resolution_ - position_.x() * resolution_;
-    float dy = p.y() * resolution_ - position_.y() * resolution_;
-    float dist = sqrt( pow(dx,2) + pow(dy,2) );
-    return dist <= 0.3;
-  }
-  
+
   /**
   @brief Draws the tag in the map
   @param img [QImage*] The image to draw to
@@ -87,7 +64,7 @@ namespace stdr_gui{
         2 * i * step, 
         2 * i * step);
     }
-    
+
     //!< Draws the label
     
     int text_size = name_.size();

--- a/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_sound_source.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_sound_source.cpp
@@ -30,9 +30,7 @@ namespace stdr_gui{
   @return void
   **/
   CGuiSoundSource::CGuiSoundSource(QPoint p,std::string name, float resolution):
-    position_(p),
-    name_(name),
-    resolution_(resolution),
+    CGuiSource(p,name,resolution),
     db_(0.0)
   {
   
@@ -46,29 +44,7 @@ namespace stdr_gui{
   {
 
   }
-  
-  /**
-  @brief Returns the "name" of the rfid tag
-  @return std::string 
-  **/
-  std::string CGuiSoundSource::getName(void)
-  {
-    return name_;
-  }
-  
-  /**
-  @brief Checks proximity to a point
-  @param p [QPoint] The proximity point to check
-  @return bool : True if tag is close to p
-  **/
-  bool CGuiSoundSource::checkProximity(QPoint p)
-  {
-    float dx = p.x() * resolution_ - position_.x() * resolution_;
-    float dy = p.y() * resolution_ - position_.y() * resolution_;
-    float dist = sqrt( pow(dx,2) + pow(dy,2) );
-    return dist <= 0.3;
-  }
-  
+
   /**
   @brief Draws the tag in the map
   @param img [QImage*] The image to draw to
@@ -87,7 +63,7 @@ namespace stdr_gui{
         2 * i * step, 
         2 * i * step);
     }
-    
+
     //!< Draws the label
     
     int text_size = name_.size();

--- a/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_source.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_source.cpp
@@ -1,0 +1,72 @@
+/******************************************************************************
+   STDR Simulator - Simple Two DImensional Robot Simulator
+   Copyright (C) 2013 STDR Simulator
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+   
+   Authors : 
+   * Manos Tsardoulias, etsardou@gmail.com
+   * Aris Thallas, aris.thallas@gmail.com
+   * Chris Zalidis, zalidis@gmail.com 
+******************************************************************************/
+  
+#include "stdr_gui/stdr_map_metainformation/stdr_gui_source.h"
+
+namespace stdr_gui{
+
+  /**
+  @brief Default contructor
+  @param p [QPoint] The pose of the rfid tag
+  @param name [std::string] The "name" of the rfid tag
+  @return void
+  **/
+  CGuiSource::CGuiSource(QPoint p,std::string name, float resolution):
+    position_(p),
+    name_(name),
+    resolution_(resolution)
+  {
+
+  }
+  
+  /**
+  @brief Default destructor
+  @return void
+  **/
+  CGuiSource::~CGuiSource(void)
+  {
+    
+  }
+
+  /**
+  @brief Returns the "name" of the source
+  @return std::string 
+  **/
+  std::string CGuiSource::getName(void)
+  {
+    return name_;
+  }
+  
+  /**
+  @brief Checks proximity to a point
+  @param p [QPoint] The proximity point to check
+  @return bool : True if tag is close to p
+  **/
+  bool CGuiSource::checkProximity(QPoint p)
+  {
+    float dx = p.x() * resolution_ - position_.x() * resolution_;
+    float dy = p.y() * resolution_ - position_.y() * resolution_;
+    float dist = sqrt( pow(dx,2) + pow(dy,2) );
+    return dist <= 0.3;
+  }
+
+}
+

--- a/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_thermal_source.cpp
+++ b/stdr_gui/src/stdr_gui/stdr_map_metainformation/stdr_gui_thermal_source.cpp
@@ -29,12 +29,9 @@ namespace stdr_gui{
   @param name [std::string] The "name" of the rfid tag
   @return void
   **/
-  CGuiThermalSource::CGuiThermalSource(
-    QPoint p,std::string name, float resolution):
-      position_(p),
-      name_(name),
-      resolution_(resolution),
-      degrees_(0.0)
+  CGuiThermalSource::CGuiThermalSource(QPoint p,std::string name, float resolution):
+	  CGuiSource(p,name,resolution),
+          degrees_(0.0)
   {
   
   }
@@ -47,29 +44,7 @@ namespace stdr_gui{
   {
 
   }
-  
-  /**
-  @brief Returns the "name" of the rfid tag
-  @return std::string 
-  **/
-  std::string CGuiThermalSource::getName(void)
-  {
-    return name_;
-  }
-  
-  /**
-  @brief Checks proximity to a point
-  @param p [QPoint] The proximity point to check
-  @return bool : True if tag is close to p
-  **/
-  bool CGuiThermalSource::checkProximity(QPoint p)
-  {
-    float dx = p.x() * resolution_ - position_.x() * resolution_;
-    float dy = p.y() * resolution_ - position_.y() * resolution_;
-    float dist = sqrt( pow(dx,2) + pow(dy,2) );
-    return dist <= 0.3;
-  }
-  
+
   /**
   @brief Draws the tag in the map
   @param img [QImage*] The image to draw to
@@ -88,7 +63,7 @@ namespace stdr_gui{
         2 * i * step, 
         2 * i * step);
     }
-    
+
     //!< Draws the label
     
     int text_size = name_.size();


### PR DESCRIPTION
# Goal

I redesigned the **stdr_gui** package to make it more maintanable by removing code duplication.
I included all common code between different source types (as well as RFID tags) in a base class named
**CGuiSource**.
## Implementation

All data members and functionality that are common between source types are moved into the abstract base class: **CGuiSource**. The only function differing between types is declared pure virtual and is overriden by the sub classes to offer the previous functionality.
## Testing

Any launcher that includes the GUI component can be used to test the new package. The functionality is exactly the same as in the master branch, but _loc_ are substantially reduced.
