### PR TITLE
Parser Node now self-manages the destruction of its children-nodes

### DIFF
--- a/stdr_parser/include/stdr_parser/stdr_parser.h
+++ b/stdr_parser/include/stdr_parser/stdr_parser.h
@@ -96,12 +96,10 @@ namespace stdr_parser
         }
         catch(ParserException ex)
         {
-          base_node_->unallocateChildren();
           delete base_node_;
           throw ex;
         }
         T msg = MessageCreator::createMessage<T>(base_node_,0);
-        base_node_->unallocateChildren();
         delete base_node_;
         return msg;
       }

--- a/stdr_parser/include/stdr_parser/stdr_parser_node.h
+++ b/stdr_parser/include/stdr_parser/stdr_parser_node.h
@@ -37,6 +37,12 @@ namespace stdr_parser
   class Node
   {
     private:
+      
+      /**
+       * @brief Unalloates the memory of the node's children
+       * @return void
+       */
+      void unallocateChildren(void);
 
     public:
     
@@ -45,7 +51,13 @@ namespace stdr_parser
       @return void
       **/
       Node(void);
-      
+
+      /**
+      @brief Destructor who also destroys all its children.
+      @return void
+      **/ 
+      ~Node(void);
+
       /**
       @brief Checks a node if a specific filename exists
       @return void
@@ -89,12 +101,7 @@ namespace stdr_parser
       @return void
       **/
       void printParsedXml(Node *n,std::string indent);
-      
-      /**
-       * @brief Unalloates the memory of the node's children
-       * @return void
-       */
-      void unallocateChildren(void);
+
   };
   
 }

--- a/stdr_parser/src/stdr_parser.cpp
+++ b/stdr_parser/src/stdr_parser.cpp
@@ -80,7 +80,6 @@ namespace stdr_parser
         file_name + std::string("'") +
         std::string("\nError was '") + std::string(e.what());
       
-      base_node_->unallocateChildren();
       delete base_node_;
       
       throw ParserException(error);

--- a/stdr_parser/src/stdr_parser_node.cpp
+++ b/stdr_parser/src/stdr_parser_node.cpp
@@ -32,6 +32,11 @@ namespace stdr_parser
     priority = 0;
   }
   
+  Node::~Node(void)
+  {
+	this->unallocateChildren();
+  }
+
   /**
   @brief Checks a node if a specific filename exists
   @return void
@@ -104,14 +109,14 @@ namespace stdr_parser
   }
   
   /**
-  * @brief Unalloates the memory of the node's children
+  * @brief Unallocates the memory of the node's children
   * @return void
   */
   void Node::unallocateChildren(void)
   {
     for(unsigned int i = 0 ; i < elements.size() ; i++)
     {
-      elements[i]->unallocateChildren();
+
       delete elements[i];
     }
   }

--- a/stdr_server/CMakeLists.txt
+++ b/stdr_server/CMakeLists.txt
@@ -37,7 +37,6 @@ include_directories( include ${catkin_INCLUDE_DIRS})
 
 add_library(stdr_map_loader src/map_loader.cpp)
 target_link_libraries(stdr_map_loader
-    image_loader
     yaml-cpp
     ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
<h1>Goal</h1>

Parser Node should manage the deletion of their children nodes on their own, thus not requiring 
external calls to memory de-allocation functions and following the 
<a href="https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization">RAII</a> idiom. This makes the code cleaner as client code does not bother with memory management of his object, the object manages its own memory. This lowers the risk of a leak that a careless developer could cause by calling delete on a Node without calling unallocate right before that.

<h2>Implementation</h2>

The (previously public) method unallocateChildren is now private and only called by the destructor.

<h2>Testing</h2>

All launcher examples provide in the launchers package seem to work fine.
