### PR TITLE
Include roslib dependency

### DIFF
--- a/stdr_samples/CMakeLists.txt
+++ b/stdr_samples/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(stdr_samples)
 
 find_package(catkin REQUIRED COMPONENTS
+  roslib
   roscpp
   tf
   stdr_msgs
@@ -22,6 +23,7 @@ catkin_package(
     include
   LIBRARIES
   CATKIN_DEPENDS
+    roslib
     roscpp
     tf
     stdr_msgs

--- a/stdr_samples/package.xml
+++ b/stdr_samples/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>roslib</depend>
   <depend>roscpp</depend>
   <depend>tf</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Fix for `ros/package.h` not found.
