### PR TITLE
Publish sensors tfs as static, and allow configuring odom frequency

### DIFF
--- a/stdr_robot/CMakeLists.txt
+++ b/stdr_robot/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   nodelet
   actionlib
   tf
+  tf2_ros
   stdr_msgs
   stdr_parser
   geometry_msgs
@@ -30,6 +31,7 @@ catkin_package(
     nodelet
     actionlib
     tf
+    tf2_ros
     stdr_msgs
     stdr_parser
     geometry_msgs

--- a/stdr_robot/include/stdr_robot/stdr_robot.h
+++ b/stdr_robot/include/stdr_robot/stdr_robot.h
@@ -25,6 +25,7 @@
 #include <ros/ros.h>
 #include <nodelet/nodelet.h>
 #include <tf/transform_broadcaster.h>
+#include <tf2_ros/static_transform_broadcaster.h>
 #include <stdr_msgs/RobotMsg.h>
 #include <stdr_msgs/MoveRobot.h>
 #include <stdr_robot/sensors/sensor_base.h>
@@ -149,6 +150,9 @@ namespace stdr_robot {
     
     //!< ROS tf transform broadcaster
     tf::TransformBroadcaster _tfBroadcaster;
+
+    //!< ROS tf2 static transform broadcaster
+    tf2_ros::StaticTransformBroadcaster static_broadcaster;
 
     //!< Odometry Publisher
     ros::Publisher _odomPublisher;

--- a/stdr_robot/include/stdr_robot/stdr_robot.h
+++ b/stdr_robot/include/stdr_robot/stdr_robot.h
@@ -152,7 +152,7 @@ namespace stdr_robot {
     tf::TransformBroadcaster _tfBroadcaster;
 
     //!< ROS tf2 static transform broadcaster
-    tf2_ros::StaticTransformBroadcaster static_broadcaster;
+    tf2_ros::StaticTransformBroadcaster _tfStaticBroadcaster;
 
     //!< Odometry Publisher
     ros::Publisher _odomPublisher;

--- a/stdr_robot/package.xml
+++ b/stdr_robot/package.xml
@@ -18,6 +18,7 @@
 
   <depend>roscpp</depend>
   <depend>tf</depend>
+  <depend>tf2_ros</depend>
   <depend>sensor_msgs</depend>
   <depend>stdr_msgs</depend>
   <depend>stdr_parser</depend>


### PR DESCRIPTION
As explained in this [ROS answer](https://answers.ros.org/question/273432/stdr-simulator-how-to-increase-static-tf-frequency/), the 10Hz at witch STDR publishes odom and sensors TFs causes important delays when processing sensor readings. So solution has two parts:

- Broadcast sensor tfs as static (though this will probably require changes on PR #201 to republish the static tf if pose changes). This is already a good thing by itself, as it reduces simulation cost.
- Allow speeding up odom tf (and odom topic) with a parameter odometry_rate