### PR TITLE
Update stdr_specifications.xml

### DIFF
--- a/stdr_resources/resources/specifications/stdr_specifications.xml
+++ b/stdr_resources/resources/specifications/stdr_specifications.xml
@@ -24,7 +24,7 @@
   </robot>
 
   <robot_specifications>
-    <allowed>initial_pose,footprint,laser,sonar,rfid_reader,kinematic</allowed>
+    <allowed>initial_pose,footprint,laser,sonar,rfid_reader,kinematic,co2_sensor</allowed>
   </robot_specifications>
 
   <initial_pose>


### PR DESCRIPTION
co2 sensor was allowed in older versions of stdr but now it can't be used unless this line is edited as you know. Thank you!